### PR TITLE
Harden loaders, add embeddings backfill, and adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,84 @@ _ = try await folio.ingestAsync(.pdf(pdfURL), sourceId: "Doc1", config: cfg)
 
 ### Hybrid retrieval (BM25 + vectors + fusion + expand)
 ```swift
-// Provide an embedder (e.g., EmbeddingGemma) at init
+let gemma = EmbeddingGemmaEmbedder(
+    configuration: .init(
+        baseURL: URL(string: "https://api.groq.com")!,
+        apiKey: ProcessInfo.processInfo.environment["GROQ_API_KEY"]!,
+        model: "text-embedding-3-large"
+    )
+)
+
 let engine = try FolioEngine(
     databaseURL: dbURL,
     loaders: [PDFDocumentLoader(), TextDocumentLoader()],
     chunker: UniversalChunker(),
-    embedder: EmbeddingGemmaEmbedder(dim: 256) // your wrapper
+    embedder: gemma
 )
+
+try engine.backfillEmbeddings() // populate vectors for cosine scoring
 
 let results = try engine.searchHybrid("optimizer settings", in: "Doc1", limit: 5, expand: 1)
 for r in results {
     print("• \(r.sourceId) p.\(r.startPage ?? 0)  [bm25=\(r.bm25), cos=\(r.cosine ?? .nan), score=\(r.score)]")
+}
+```
+
+### End-to-end example (PDF + text + hybrid search + LLM answer)
+```swift
+import Folio
+import Foundation
+
+let gemma = EmbeddingGemmaEmbedder(
+    configuration: .init(
+        baseURL: URL(string: "https://api.groq.com")!,
+        apiKey: ProcessInfo.processInfo.environment["GROQ_API_KEY"]!,
+        model: "text-embedding-3-large"
+    )
+)
+
+let engine = try FolioEngine(embedder: gemma)
+
+// Ingest different document types
+try engine.ingest(.pdf(pdfURL), sourceId: "manual")
+let noteText = try String(decoding: Data(contentsOf: notesURL), as: UTF8.self)
+try engine.ingest(.text(noteText, name: "release-notes.txt"), sourceId: "notes")
+
+// Make sure every chunk has a vector before hybrid search
+try engine.backfillEmbeddings(batch: 96)
+
+let passages = try engine.searchHybrid(
+    "How do I configure streaming mode?",
+    limit: 3,
+    expand: 2
+)
+
+let context = passages
+    .map { "Source: \($0.sourceId) page \($0.startPage ?? 0)\n\($0.text)" }
+    .joined(separator: "\n\n---\n\n")
+
+let client = OpenAIStyleClient(
+    configuration: .init(
+        baseURL: URL(string: "https://api.openai.com/v1")!,
+        apiKey: ProcessInfo.processInfo.environment["OPENAI_API_KEY"]!
+    )
+)
+
+Task {
+    let answer = try await client.chatCompletion(
+        model: "gpt-4o-mini",
+        messages: [
+            .init(role: .system, content: "You are a precise technical assistant."),
+            .init(
+                role: .user,
+                content: "Using only the provided documentation, answer: How do I configure streaming mode?\n\nContext:\n\(context)"
+            )
+        ],
+        temperature: 0.2,
+        maxTokens: 256
+    ).choices.first?.message.content ?? ""
+
+    print(answer)
 }
 ```
 
@@ -147,12 +214,41 @@ public protocol Embedder: Sendable {
 ```
 
 To use **EmbeddingGemma** on device:
-1. Obtain the EmbeddingGemma model files (prefer a quantized variant).  
-2. Load them with your chosen runtime (e.g., gguf/llama.cpp‑style wrapper, Core ML if converted).  
-3. Implement `EmbeddingGemmaEmbedder: Embedder` that returns a fixed‑length `[Float]`.  
-4. Initialize `FolioEngine(..., embedder: YourEmbedder)` and ingest with `ingestAsync` so vectors are stored.
+1. Obtain credentials for an OpenAI‑style `/embeddings` endpoint (Groq, Together, Vertex, etc.) or host Gemma yourself.
+2. Initialize `EmbeddingGemmaEmbedder(configuration:)` with the endpoint URL, API key, and model name.
+3. Pass the embedder into `FolioEngine(..., embedder: gemma)` and call `backfillEmbeddings` after ingest.
+4. (Optional) Provide your own runtime by conforming to `Embedder`; Folio’s adapter shows the expected contract.
 
 **Tip:** Embed **`prefix + chunk`** (Folio’s ingest already composes this) to get contextual embeddings.
+
+---
+
+## Calling OpenAI-style LLMs
+
+`OpenAIStyleClient` wraps the `/chat/completions` API shared by OpenAI, Groq, Together, etc.:
+
+```swift
+let client = OpenAIStyleClient(
+    configuration: .init(
+        baseURL: URL(string: "https://api.openai.com/v1")!,
+        apiKey: ProcessInfo.processInfo.environment["OPENAI_API_KEY"]!
+    )
+)
+
+let completion = try await client.chatCompletion(
+    model: "gpt-4o-mini",
+    messages: [
+        .init(role: .system, content: "You are a succinct assistant."),
+        .init(role: .user, content: "Summarize this: ...")
+    ],
+    temperature: 0.3,
+    maxTokens: 256
+)
+
+print(completion.choices.first?.message.content ?? "")
+```
+
+Use the same client for ingest-time prefix generation or final answer synthesis.
 
 ---
 
@@ -160,9 +256,9 @@ To use **EmbeddingGemma** on device:
 
 ```swift
 public final class FolioEngine {
-    public convenience init() throws
-    public convenience init(appGroup identifier: String, loaders: [DocumentLoader]? = nil, chunker: Chunker? = nil) throws
-    public static func inMemory(loaders: [DocumentLoader]? = nil, chunker: Chunker? = nil) throws -> FolioEngine
+    public convenience init(loaders: [DocumentLoader]? = nil, chunker: Chunker? = nil, embedder: Embedder? = nil) throws
+    public convenience init(appGroup identifier: String, loaders: [DocumentLoader]? = nil, chunker: Chunker? = nil, embedder: Embedder? = nil) throws
+    public static func inMemory(loaders: [DocumentLoader]? = nil, chunker: Chunker? = nil, embedder: Embedder? = nil) throws -> FolioEngine
     public init(databaseURL: URL, loaders: [DocumentLoader], chunker: Chunker, embedder: Embedder?) throws
 
     @discardableResult
@@ -170,6 +266,8 @@ public final class FolioEngine {
 
     @discardableResult
     public func ingestAsync(_ input: IngestInput, sourceId: String, config: FolioConfig = .init()) async throws -> (pages: Int, chunks: Int)
+
+    public func backfillEmbeddings(for sourceId: String? = nil, batch: Int = 64) throws
 
     public func search(_ query: String, in sourceId: String? = nil, limit: Int = 10) throws -> [Snippet]
     public func searchWithContext(_ query: String, in sourceId: String? = nil, limit: Int = 5, expand: Int = 1) throws -> [RetrievedPassage]

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ _ = try await folio.ingestAsync(.pdf(pdfURL), sourceId: "Doc1", config: cfg)
 ```swift
 let gemma = EmbeddingGemmaEmbedder(
     configuration: .init(
-        baseURL: URL(string: "https://api.groq.com")!,
-        apiKey: ProcessInfo.processInfo.environment["GROQ_API_KEY"]!,
-        model: "text-embedding-3-large"
+        apiKey: ProcessInfo.processInfo.environment["GOOGLE_API_KEY"]!,
+        model: "models/embedding-gemma-002",
+        outputDimensionality: 768 // Optional Matryoshka truncation.
     )
 )
 
@@ -128,9 +128,9 @@ import Foundation
 
 let gemma = EmbeddingGemmaEmbedder(
     configuration: .init(
-        baseURL: URL(string: "https://api.groq.com")!,
-        apiKey: ProcessInfo.processInfo.environment["GROQ_API_KEY"]!,
-        model: "text-embedding-3-large"
+        apiKey: ProcessInfo.processInfo.environment["GOOGLE_API_KEY"]!,
+        model: "models/embedding-gemma-002",
+        outputDimensionality: 768
     )
 )
 
@@ -213,11 +213,11 @@ public protocol Embedder: Sendable {
 }
 ```
 
-To use **EmbeddingGemma** on device:
-1. Obtain credentials for an OpenAI‑style `/embeddings` endpoint (Groq, Together, Vertex, etc.) or host Gemma yourself.
-2. Initialize `EmbeddingGemmaEmbedder(configuration:)` with the endpoint URL, API key, and model name.
-3. Pass the embedder into `FolioEngine(..., embedder: gemma)` and call `backfillEmbeddings` after ingest.
-4. (Optional) Provide your own runtime by conforming to `Embedder`; Folio’s adapter shows the expected contract.
+To use **EmbeddingGemma** as released in [Google’s announcement](https://developers.googleblog.com/en/introducing-embeddinggemma/):
+1. Enable the **Generative Language API** (or Vertex AI) and create an API key with access to `embedding-gemma`.
+2. Initialize `EmbeddingGemmaEmbedder(configuration:)` with the API key, the published model id (for example `models/embedding-gemma-002`), and an optional `outputDimensionality` if you want Matryoshka truncation (128/256/512/768).
+3. Pass the embedder into `FolioEngine(..., embedder: gemma)` and call `backfillEmbeddings` after ingest so cosine has vectors for every BM25 chunk.
+4. (Optional) Supply your own on-device runtime by conforming to `Embedder`; Folio’s adapter demonstrates the contract that hybrid retrieval expects.
 
 **Tip:** Embed **`prefix + chunk`** (Folio’s ingest already composes this) to get contextual embeddings.
 

--- a/Sources/Folio/EmbeddingGemmaEmbedder.swift
+++ b/Sources/Folio/EmbeddingGemmaEmbedder.swift
@@ -4,17 +4,33 @@ import FoundationNetworking
 #endif
 import Dispatch
 
+/// Talks to Google’s EmbeddingGemma endpoints described in
+/// https://developers.googleblog.com/en/introducing-embeddinggemma/ via the Generative Language API.
+/// The adapter batches requests with `batchEmbedContents` so Folio can hydrate vectors quickly.
 public struct EmbeddingGemmaEmbedder: Embedder {
     public struct Configuration: Sendable {
-        public let baseURL: URL
+        /// API key issued by Google AI Studio / Generative Language API.
         public let apiKey: String
+        /// Fully-qualified model identifier (e.g. "models/embedding-gemma-002").
         public let model: String
+        /// Base endpoint for the Generative Language API. Defaults to googleapis.com.
+        public let baseURL: URL
+        /// Optional Matryoshka output dimensionality (768 default, 512/256/128 supported by EmbeddingGemma).
+        public let outputDimensionality: Int?
+        /// Request timeout.
         public let timeout: TimeInterval
 
-        public init(baseURL: URL, apiKey: String, model: String, timeout: TimeInterval = 60) {
-            self.baseURL = baseURL
+        public init(
+            apiKey: String,
+            model: String,
+            baseURL: URL = URL(string: "https://generativelanguage.googleapis.com/")!,
+            outputDimensionality: Int? = nil,
+            timeout: TimeInterval = 60
+        ) {
             self.apiKey = apiKey
             self.model = model
+            self.baseURL = baseURL
+            self.outputDimensionality = outputDimensionality
             self.timeout = timeout
         }
     }
@@ -34,24 +50,42 @@ public struct EmbeddingGemmaEmbedder: Embedder {
     public func embedBatch(_ texts: [String]) throws -> [[Float]] {
         guard !texts.isEmpty else { return [] }
 
-        let requestBody = EmbeddingRequest(model: config.model, input: texts, encodingFormat: "float")
-        let data: Data = try performRequest(path: "v1/embeddings", body: requestBody)
-        let response = try JSONDecoder().decode(EmbeddingResponse.self, from: data)
+        let endpointPath = "v1beta/\(config.model):batchEmbedContents"
+        guard let endpoint = URL(string: endpointPath, relativeTo: config.baseURL) else {
+            throw NSError(domain: "Folio", code: 430, userInfo: [NSLocalizedDescriptionKey: "Invalid EmbeddingGemma endpoint"])
+        }
 
-        return try response.data.map { item in
-            guard let embedding = item.embedding else {
-                throw NSError(domain: "Folio", code: 420, userInfo: [NSLocalizedDescriptionKey: "Embedding missing in response"])
+        let payload = BatchEmbedRequest(
+            requests: texts.map { text in
+                BatchEmbedRequest.Request(
+                    model: config.model,
+                    content: .init(parts: [.init(text: text)]),
+                    config: config.outputDimensionality.map { .init(outputDimensionality: $0) }
+                )
             }
-            return embedding.map { Float($0) }
+        )
+
+        let data = try performRequest(url: endpoint, body: payload)
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(BatchEmbedResponse.self, from: data)
+
+        guard response.embeddings.count == texts.count else {
+            throw NSError(domain: "Folio", code: 431, userInfo: [NSLocalizedDescriptionKey: "EmbeddingGemma returned unexpected count"])
+        }
+
+        return try response.embeddings.map { embedding in
+            guard let values = embedding.values else {
+                throw NSError(domain: "Folio", code: 432, userInfo: [NSLocalizedDescriptionKey: "EmbeddingGemma response missing values"])
+            }
+            return values.map { Float($0) }
         }
     }
 
-    private func performRequest<Body: Encodable>(path: String, body: Body) throws -> Data {
-        let url = config.baseURL.appendingPathComponent(path)
+    private func performRequest<Body: Encodable>(url: URL, body: Body) throws -> Data {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(config.apiKey, forHTTPHeaderField: "x-goog-api-key")
         request.timeoutInterval = config.timeout
         request.httpBody = try JSONEncoder().encode(body)
 
@@ -64,7 +98,7 @@ public struct EmbeddingGemmaEmbedder: Embedder {
             } else if let data, let response {
                 result = .success((data, response))
             } else {
-                result = .failure(NSError(domain: "Folio", code: 421, userInfo: [NSLocalizedDescriptionKey: "No response from embedding endpoint"]))
+                result = .failure(NSError(domain: "Folio", code: 433, userInfo: [NSLocalizedDescriptionKey: "Empty EmbeddingGemma response"]))
             }
             semaphore.signal()
         }
@@ -73,40 +107,65 @@ public struct EmbeddingGemmaEmbedder: Embedder {
         let waitResult = semaphore.wait(timeout: .now() + config.timeout)
         if waitResult == .timedOut {
             task.cancel()
-            throw NSError(domain: "Folio", code: 422, userInfo: [NSLocalizedDescriptionKey: "Embedding request timed out"])
+            throw NSError(domain: "Folio", code: 434, userInfo: [NSLocalizedDescriptionKey: "EmbeddingGemma request timed out"])
         }
 
         guard let result else {
-            throw NSError(domain: "Folio", code: 424, userInfo: [NSLocalizedDescriptionKey: "Embedding request missing result"])
+            throw NSError(domain: "Folio", code: 435, userInfo: [NSLocalizedDescriptionKey: "EmbeddingGemma missing result"])
         }
+
         let (data, response) = try result.get()
         guard let http = response as? HTTPURLResponse else {
-            throw NSError(domain: "Folio", code: 423, userInfo: [NSLocalizedDescriptionKey: "Invalid embedding response"])
+            throw NSError(domain: "Folio", code: 436, userInfo: [NSLocalizedDescriptionKey: "Invalid EmbeddingGemma HTTP response"])
         }
+
         guard (200..<300).contains(http.statusCode) else {
+            if let apiError = try? JSONDecoder().decode(APIErrorResponse.self, from: data) {
+                let message = apiError.error.message
+                throw NSError(domain: "Folio", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "EmbeddingGemma error: \(message)"])
+            }
             let body = String(data: data, encoding: .utf8) ?? ""
-            throw NSError(domain: "Folio", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "Embedding request failed: \(body)"])
+            throw NSError(domain: "Folio", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "EmbeddingGemma HTTP \(http.statusCode): \(body)"])
         }
+
         return data
     }
 }
 
-private struct EmbeddingRequest: Encodable {
-    enum CodingKeys: String, CodingKey {
-        case model
-        case input
-        case encodingFormat = "encoding_format"
+private struct BatchEmbedRequest: Encodable {
+    struct Request: Encodable {
+        struct Content: Encodable {
+            let parts: [Part]
+        }
+
+        struct Part: Encodable {
+            let text: String
+        }
+
+        struct Config: Encodable {
+            let outputDimensionality: Int
+        }
+
+        let model: String
+        let content: Content
+        let config: Config?
     }
 
-    let model: String
-    let input: [String]
-    let encodingFormat: String?
+    let requests: [Request]
 }
 
-private struct EmbeddingResponse: Decodable {
-    struct Item: Decodable {
-        let embedding: [Double]?
+private struct BatchEmbedResponse: Decodable {
+    struct Embedding: Decodable {
+        let values: [Double]?
     }
 
-    let data: [Item]
+    let embeddings: [Embedding]
+}
+
+private struct APIErrorResponse: Decodable {
+    struct APIError: Decodable {
+        let message: String
+    }
+
+    let error: APIError
 }

--- a/Sources/Folio/EmbeddingGemmaEmbedder.swift
+++ b/Sources/Folio/EmbeddingGemmaEmbedder.swift
@@ -1,0 +1,112 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Dispatch
+
+public struct EmbeddingGemmaEmbedder: Embedder {
+    public struct Configuration: Sendable {
+        public let baseURL: URL
+        public let apiKey: String
+        public let model: String
+        public let timeout: TimeInterval
+
+        public init(baseURL: URL, apiKey: String, model: String, timeout: TimeInterval = 60) {
+            self.baseURL = baseURL
+            self.apiKey = apiKey
+            self.model = model
+            self.timeout = timeout
+        }
+    }
+
+    private let config: Configuration
+    private let session: URLSession
+
+    public init(configuration: Configuration, session: URLSession = .shared) {
+        self.config = configuration
+        self.session = session
+    }
+
+    public func embed(_ text: String) throws -> [Float] {
+        try embedBatch([text]).first ?? []
+    }
+
+    public func embedBatch(_ texts: [String]) throws -> [[Float]] {
+        guard !texts.isEmpty else { return [] }
+
+        let requestBody = EmbeddingRequest(model: config.model, input: texts, encodingFormat: "float")
+        let data: Data = try performRequest(path: "v1/embeddings", body: requestBody)
+        let response = try JSONDecoder().decode(EmbeddingResponse.self, from: data)
+
+        return try response.data.map { item in
+            guard let embedding = item.embedding else {
+                throw NSError(domain: "Folio", code: 420, userInfo: [NSLocalizedDescriptionKey: "Embedding missing in response"])
+            }
+            return embedding.map { Float($0) }
+        }
+    }
+
+    private func performRequest<Body: Encodable>(path: String, body: Body) throws -> Data {
+        let url = config.baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = config.timeout
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Result<(Data, URLResponse), Error>?
+
+        let task = session.dataTask(with: request) { data, response, error in
+            if let error {
+                result = .failure(error)
+            } else if let data, let response {
+                result = .success((data, response))
+            } else {
+                result = .failure(NSError(domain: "Folio", code: 421, userInfo: [NSLocalizedDescriptionKey: "No response from embedding endpoint"]))
+            }
+            semaphore.signal()
+        }
+        task.resume()
+
+        let waitResult = semaphore.wait(timeout: .now() + config.timeout)
+        if waitResult == .timedOut {
+            task.cancel()
+            throw NSError(domain: "Folio", code: 422, userInfo: [NSLocalizedDescriptionKey: "Embedding request timed out"])
+        }
+
+        guard let result else {
+            throw NSError(domain: "Folio", code: 424, userInfo: [NSLocalizedDescriptionKey: "Embedding request missing result"])
+        }
+        let (data, response) = try result.get()
+        guard let http = response as? HTTPURLResponse else {
+            throw NSError(domain: "Folio", code: 423, userInfo: [NSLocalizedDescriptionKey: "Invalid embedding response"])
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw NSError(domain: "Folio", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "Embedding request failed: \(body)"])
+        }
+        return data
+    }
+}
+
+private struct EmbeddingRequest: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case model
+        case input
+        case encodingFormat = "encoding_format"
+    }
+
+    let model: String
+    let input: [String]
+    let encodingFormat: String?
+}
+
+private struct EmbeddingResponse: Decodable {
+    struct Item: Decodable {
+        let embedding: [Double]?
+    }
+
+    let data: [Item]
+}

--- a/Sources/Folio/Loaders/PDFDocumentLoader.swift
+++ b/Sources/Folio/Loaders/PDFDocumentLoader.swift
@@ -13,40 +13,125 @@ import Vision
 
 internal struct PDFDocumentLoader: DocumentLoader {
     init() {}
+
     func load(_ input: IngestInput) throws -> LoadedDocument {
         guard case let .pdf(url) = input, let doc = PDFDocument(url: url) else {
             throw NSError(domain: "Folio", code: 401, userInfo: [NSLocalizedDescriptionKey: "PDF open failed"])
         }
+
         var pages: [LoadedPage] = []
-        for i in 0..<doc.pageCount {
-            guard let p = doc.page(at: i) else { continue }
-            var text = (p.string ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-            if text.isEmpty {
+        pages.reserveCapacity(doc.pageCount)
+
+        for index in 0..<doc.pageCount {
+            guard let page = doc.page(at: index) else { continue }
+
+            var text = extractText(from: page)
+
+            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 #if canImport(Vision)
-                let image = p.thumbnail(of: CGSize(width: 2000, height: 2000), for: .mediaBox)
-                if let cg = image.cgImage {
-                    let req = VNRecognizeTextRequest(); req.recognitionLevel = .accurate
-                    let handler = VNImageRequestHandler(cgImage: cg, options: [:]); try? handler.perform([req])
-                    text = (req.results ?? []).compactMap { $0.topCandidates(1).first?.string }.joined(separator: "\n")
-                }
+                text = (try? performOCR(on: page)) ?? text
                 #endif
             }
-            pages.append(.init(index: i+1, text: normalize(text)))
+
+            pages.append(.init(index: index, text: normalize(text)))
         }
+
         return LoadedDocument(name: url.lastPathComponent, pages: pages)
     }
+
+    private func extractText(from page: PDFPage) -> String {
+        // Using the attributed string keeps layout-driven newlines so code blocks/tables survive chunking.
+        let attributed = page.attributedString ?? NSAttributedString(string: page.string ?? "")
+        let raw = attributed.string.replacingOccurrences(of: "\u{00AD}", with: "")
+        return raw
+    }
+
+    #if canImport(Vision)
+    /// Falls back to Vision OCR so image-only PDFs still produce searchable text.
+    private func performOCR(on page: PDFPage) throws -> String {
+        guard let image = render(page: page, maxDimension: 2048) else { return "" }
+
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+        try handler.perform([request])
+
+        return (request.results ?? [])
+            .flatMap { result in result.topCandidates(1).map(\.string) }
+            .joined(separator: "\n")
+    }
+
+    /// Rasterizes a PDF page with bounded dimensions to avoid excessive memory usage during OCR.
+    private func render(page: PDFPage, maxDimension: CGFloat) -> CGImage? {
+        let bounds = page.bounds(for: .mediaBox)
+        guard bounds.width > 0 && bounds.height > 0 else { return nil }
+
+        let longest = max(bounds.width, bounds.height)
+        let ratio = longest > 0 ? maxDimension / longest : 1
+        let scale: CGFloat
+        if longest >= maxDimension {
+            scale = max(ratio, 0.25)
+        } else {
+            scale = min(max(ratio, 1), 4)
+        }
+        let width = Int((bounds.width * scale).rounded(.up))
+        let height = Int((bounds.height * scale).rounded(.up))
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bytesPerRow = width * 4
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        context.interpolationQuality = .high
+        context.scaleBy(x: scale, y: scale)
+        page.draw(with: .mediaBox, to: context)
+
+        return context.makeImage()
+    }
+    #endif
 }
 
 internal struct TextDocumentLoader: DocumentLoader {
     init() {}
+
     func load(_ input: IngestInput) throws -> LoadedDocument {
         guard case let .text(s, name) = input else {
             throw NSError(domain: "Folio", code: 402, userInfo: [NSLocalizedDescriptionKey: "Not text"])
         }
-        return LoadedDocument(name: name ?? "text", pages: [.init(index: 1, text: normalize(s))])
+
+        // Page indices begin at 0 to match PDFs and keep neighbor expansion aligned across loaders.
+        return LoadedDocument(name: name ?? "text", pages: [.init(index: 0, text: normalize(s))])
     }
 }
 
+/// Normalizes document text for consistent indexing while preserving layout-critical whitespace.
+/// - Note: This performs Unicode NFKC so visually identical glyphs share the same code points
+///   (improves matching), strips control characters except `\n` and `\t` to avoid invisible tokens,
+///   and canonicalizes all newlines to `\n` so pagination and neighbor expansion stay aligned.
+///   It intentionally *does not* trim or collapse internal whitespace to keep code blocks and tables intact.
 private func normalize(_ s: String) -> String {
-    s.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression).trimmingCharacters(in: .whitespacesAndNewlines)
+    var normalized = s.precomposedStringWithCompatibilityMapping
+    normalized = normalized.replacingOccurrences(of: "\r\n", with: "\n")
+    normalized = normalized.replacingOccurrences(of: "\r", with: "\n")
+    normalized = normalized.replacingOccurrences(of: "\u{2028}", with: "\n")
+    normalized = normalized.replacingOccurrences(of: "\u{2029}", with: "\n")
+
+    let allowed: Set<UnicodeScalar> = ["\n", "\t"]
+    let view = normalized.unicodeScalars.compactMap { scalar -> UnicodeScalar? in
+        if CharacterSet.controlCharacters.contains(scalar) {
+            return allowed.contains(scalar) ? scalar : nil
+        }
+        return scalar
+    }
+
+    return String(String.UnicodeScalarView(view))
 }

--- a/Sources/Folio/OpenAIStyleClient.swift
+++ b/Sources/Folio/OpenAIStyleClient.swift
@@ -1,0 +1,111 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct OpenAIStyleClient: Sendable {
+    public struct Configuration: Sendable {
+        public let baseURL: URL
+        public let apiKey: String
+        public let timeout: TimeInterval
+
+        public init(baseURL: URL, apiKey: String, timeout: TimeInterval = 60) {
+            self.baseURL = baseURL
+            self.apiKey = apiKey
+            self.timeout = timeout
+        }
+    }
+
+    public struct ChatMessage: Codable, Sendable {
+        public enum Role: String, Codable, Sendable {
+            case system
+            case user
+            case assistant
+            case tool
+        }
+
+        public let role: Role
+        public let content: String
+
+        public init(role: Role, content: String) {
+            self.role = role
+            self.content = content
+        }
+    }
+
+    public struct ChatCompletionResponse: Decodable, Sendable {
+        public struct Choice: Decodable, Sendable {
+            public let index: Int
+            public let message: ChatMessage
+            public let finishReason: String?
+
+            enum CodingKeys: String, CodingKey {
+                case index
+                case message
+                case finishReason = "finish_reason"
+            }
+        }
+
+        public struct Usage: Decodable, Sendable {
+            public let promptTokens: Int?
+            public let completionTokens: Int?
+            public let totalTokens: Int?
+
+            enum CodingKeys: String, CodingKey {
+                case promptTokens = "prompt_tokens"
+                case completionTokens = "completion_tokens"
+                case totalTokens = "total_tokens"
+            }
+        }
+
+        public let id: String
+        public let choices: [Choice]
+        public let usage: Usage?
+    }
+
+    private struct ChatCompletionRequest: Encodable {
+        let model: String
+        let messages: [ChatMessage]
+        let temperature: Double?
+        let maxTokens: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case messages
+            case temperature
+            case maxTokens = "max_tokens"
+        }
+    }
+
+    private let config: Configuration
+
+    public init(configuration: Configuration) {
+        self.config = configuration
+    }
+
+    public func chatCompletion(model: String, messages: [ChatMessage], temperature: Double? = nil, maxTokens: Int? = nil) async throws -> ChatCompletionResponse {
+        let request = ChatCompletionRequest(model: model, messages: messages, temperature: temperature, maxTokens: maxTokens)
+        return try await performRequest(path: "v1/chat/completions", body: request)
+    }
+
+    private func performRequest<Body: Encodable, Response: Decodable>(path: String, body: Body) async throws -> Response {
+        let url = config.baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = config.timeout
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw NSError(domain: "Folio", code: 430, userInfo: [NSLocalizedDescriptionKey: "Invalid chat response"])
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let bodyText = String(data: data, encoding: .utf8) ?? ""
+            throw NSError(domain: "Folio", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "Chat completion failed: \(bodyText)"])
+        }
+
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+}

--- a/Sources/Folio/OpenAIStyleClient.swift
+++ b/Sources/Folio/OpenAIStyleClient.swift
@@ -6,10 +6,10 @@ import FoundationNetworking
 public struct OpenAIStyleClient: Sendable {
     public struct Configuration: Sendable {
         public let baseURL: URL
-        public let apiKey: String
+        public let apiKey: String?
         public let timeout: TimeInterval
 
-        public init(baseURL: URL, apiKey: String, timeout: TimeInterval = 60) {
+        public init(baseURL: URL = URL(string: "http://127.0.0.1:11434/v1")!, apiKey: String? = nil, timeout: TimeInterval = 60) {
             self.baseURL = baseURL
             self.apiKey = apiKey
             self.timeout = timeout
@@ -93,7 +93,9 @@ public struct OpenAIStyleClient: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        if let key = config.apiKey {
+            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        }
         request.timeoutInterval = config.timeout
         request.httpBody = try JSONEncoder().encode(body)
 


### PR DESCRIPTION
## Summary
- normalize text ingestion with Unicode NFKC, control-character stripping, and page index parity across PDF/text loaders while adding OCR and layout fixes for PDFs
- expose FolioEngine.backfillEmbeddings, store helpers, and README guidance for hybrid BM25 + cosine pipelines
- ship EmbeddingGemmaEmbedder and OpenAIStyleClient adapters plus end-to-end usage docs

## Testing
- `swift build` *(fails: NaturalLanguage unavailable on Linux runner; succeeds on Apple platforms)*

