### PR TITLE
Fix hyphenated newline handling in PDF normalization

### DIFF
--- a/Tests/FolioTests/FolioTests.swift
+++ b/Tests/FolioTests/FolioTests.swift
@@ -9,4 +9,16 @@ final class FolioSmokeTests: XCTestCase {
         let hits = try folio.search("hello", in: "T1", limit: 1)
         XCTAssertFalse(hits.isEmpty)
     }
+
+    func testNormalizeRemovesHyphenWraps() throws {
+        let loader = TextDocumentLoader()
+        let document = try loader.load(.text("multi-\nline\nre-entry", name: "mock.pdf"))
+
+        guard let text = document.pages.first?.text else {
+            XCTFail("Missing normalized text")
+            return
+        }
+
+        XCTAssertEqual(text, "multiline\nre-entry")
+    }
 }


### PR DESCRIPTION
## Summary
- collapse hyphen-like characters followed by a newline and letter during normalization so wrapped words rejoin correctly
- ensure true hyphenation such as "re-entry" remains intact
- cover the behavior with a loader unit test using wrapped text input

## Testing
- swift test *(fails: no such module 'NaturalLanguage' in the current toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb3041c30833388e0e1591f2b3283