### PR TITLE
Make loader initializers public

### DIFF
--- a/Sources/Folio/Loaders/PDFDocumentLoader.swift
+++ b/Sources/Folio/Loaders/PDFDocumentLoader.swift
@@ -12,7 +12,7 @@ import Vision
 #endif
 
 public struct PDFDocumentLoader: DocumentLoader {
-    init() {}
+    public init() {}
 
     public func load(_ input: IngestInput) throws -> LoadedDocument {
         guard case let .pdf(url) = input, let doc = PDFDocument(url: url) else {
@@ -101,7 +101,7 @@ public struct PDFDocumentLoader: DocumentLoader {
 }
 
 public struct TextDocumentLoader: DocumentLoader {
-    init() {}
+    public init() {}
 
     public func load(_ input: IngestInput) throws -> LoadedDocument {
         guard case let .text(s, name) = input else {


### PR DESCRIPTION
## Summary
- expose public initializers for PDFDocumentLoader and TextDocumentLoader so they are constructible by clients

## Testing
- `swift build` *(fails: no such module 'NaturalLanguage' in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc6e6e24083338dda69c991e01744