### PR TITLE
Ensure deleteSource removes source metadata and chunks

### DIFF
--- a/Sources/Folio/FolioEngine.swift
+++ b/Sources/Folio/FolioEngine.swift
@@ -378,7 +378,7 @@ public final class FolioEngine {
     }
     
     public func deleteSource(_ sourceId: String) throws {
-        try store.deleteChunks(forSourceId: sourceId)
+        try store.deleteSource(id: sourceId)
     }
     
     public func listSources() throws -> [Source] {

--- a/Tests/FolioTests/FolioTests.swift
+++ b/Tests/FolioTests/FolioTests.swift
@@ -79,4 +79,15 @@ final class FolioSmokeTests: XCTestCase {
         let truncated = try engine.fetchDocument(sourceId: "Doc1", maxChars: 20)
         XCTAssertLessThanOrEqual(truncated.text.count, 20)
     }
+
+    func testDeleteSourceRemovesSource() throws {
+        let engine = try FolioEngine.inMemory()
+        _ = try engine.ingest(.text("hello world", name: "note.txt"), sourceId: "Doc1")
+
+        XCTAssertEqual(try engine.listSources().count, 1)
+
+        try engine.deleteSource("Doc1")
+
+        XCTAssertTrue(try engine.listSources().isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- update `FolioEngine.deleteSource` to delegate to `DocChunkStore.deleteSource`
- add a unit test that ingests then deletes a source and verifies it no longer appears in listings

## Testing
- swift test *(fails: package 'folio' is using Swift tools version 6.2.0 but the installed version is 6.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_6906e49e667c8333938cbb459a485e9d